### PR TITLE
Count down for final end if max_min provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,18 @@ At least 4 GB of RAM is recommended.
 
 The following configuration options are provided:
 
-- `min_per_end`: Minutes per end for pacing, default 15.
 - `countdown_min`: Starting value of countdown timer in minutes, default 105.
-- `elapsed_min`: If timer is accidentally started late, adjust this value for minutes elapsed since the draw started. This allows the countdown to start later without affecting progress, default 0. This value needs to be reset back to 0 prior to beginning the next draw, so that it gets the full time!
-- `zero_message`: Message to be displayed when the timer hits zero, default "FINISH THIS END".
-- `max_min`: After hitting zero, the timer begins to count up. If this value is set, once `max_min` have elapsed (including countdown time), the timer stops counting completely and displays `max_message`. Default is `None`, timer will count up until stopped.
-- `max_message`: Message to be displayed after `max_min` have elapsed. Default "TIME'S UP"
-- `num_stones`: Total number of stones per end, default 16. Primarily modified for doubles.
-- `total_ends`: Number of ends to include in progress bar, default 8.
-- `progress_update_percentage`: Percentage difference between progress bar re-renders, default 5.
+- `elapsed_min`: If timer is accidentally started late, adjust this value for minutes elapsed since the draw started. This allows the countdown to start later without affecting progress, default 0. This value needs to be reset back to 0 prior to beginning the next draw, so that it gets the full time! 
 - `elapsed_min_out_file`: If provided, a file containing elapsed minutes will be generated. Useful in case of (e.g power) failure.
+- `max_message`: Message to be displayed after `max_min` have elapsed. Default "TIME'S UP"
+- `max_min`: After `countdown_min` have passed, timer will create final countdown for the last end, based
+on this value (`max_min - countdown_min`). Once `max_min` have elapsed (including countdown time), the timer stops counting completely and displays `max_message`. Default is `None` and, if unset, timer will count up infinitely after hitting 0.
+- `min_per_end`: Minutes per end for pacing, default 15.
+- `num_stones`: Total number of stones per end, default 16. Primarily modified for doubles.
+- `progress_update_percentage`: Percentage difference between progress bar re-renders, default 5.
+- `total_ends`: Number of ends to include in progress bar, default 8.
+- `warning_min`: Background color will change to yellow to warn players time is almost up when this much time is left, default 15.
+- `zero_message`: Message to be displayed when the timer hits zero, default "FINISH THIS END".
 
 If a configuration option is not present in the configuration file, the default value will be used. Sample configs are provided in `./configs/`
 

--- a/panel.py
+++ b/panel.py
@@ -22,13 +22,16 @@ class CountdownTimer:
         self.duration_s = int(config.get("countdown_min", 105) * 60)
         self.remaining_s = self.duration_s - int(config.get("elapsed_min", 0) * 60)
         self.elapsed_min = (self.duration_s - self.remaining_s) // 60
+        self.warning_s = int(config.get("warning_min", 15) * 60)
         self.zero_message = config.get("zero_message", "FINISH THIS END")
         self.elapsed_out_file = config.get("elapsed_min_out_file", None)
         max_min = config.get("max_min", None)
         if max_min is not None:
             self.max_s = int(max_min) * 60
+            self.last_end_s = self.max_s - self.duration_s
         else:
             self.max_s = None
+            self.last_end_s = None
         self.max_message = config.get("max_message", "TIME'S UP")
         self.progress_update_percentage = config.get("progress_update_percentage", 5)
         self.s_per_stone = self.s_per_end / self.num_stones
@@ -157,24 +160,29 @@ class CountdownTimer:
 
     def timer_text(self, t_s):
         """Timer display text"""
-        secs = t_s
-
-        # Start counting up after 0
+        message_html = ""
+        font_size_vw = 23
         color = "black"
         prefix = ""
-        message_html = ""
-        font_size = 500
-        if t_s <= 0:
+
+        # Once time expires, we have two cases
+        secs = t_s
+        if secs <= 0:
             secs *= -1
-            prefix = "+"
             color = "white"
-            font_size = 400
+            
+            # Countdown for the last end if max_min provided in config
+            if self.last_end_s is not None:
+                secs = self.last_end_s - secs
+            else:  # Otherwise, start counting up
+                prefix = "+"
+                font_size_vw = 22
 
         # Convert to hours:mins:seconds
         mins, secs = divmod(secs, 60)
         hours, mins = divmod(mins, 60)
 
-        html = f"<h1 style='text-align: center; color: {color}; font-size: 23vw'>" \
+        html = f"<h1 style='text-align: center; color: {color}; font-size: {font_size_vw}vw'>" \
             f"{prefix}{hours:01d}:{mins:02d}:{secs:02d}</h1>"
 
         return html
@@ -206,7 +214,7 @@ class CountdownTimer:
         self.countdown_text.object = self.timer_text(self.remaining_s)
         if self.remaining_s <= 0:
             self.content.styles = {'background-color': '#FF0000'}  # Change background color to red
-        elif self.remaining_s < 900:  # change to yellow with 15 mins (900s) left
+        elif self.remaining_s < self.warning_s:  # change to yellow with warning_s left
             self.content.styles = {'background-color': '#FFFF00'}
         else:
             self.content.styles = {'background-color': "#99FF99"}


### PR DESCRIPTION
- If `max_min` is set, the timer now counts down (for `max_min - countdown_min`) for the last end instead of counting up after hitting zero
- Added a configuration option to determine when the timer turns to the warning color (yellow)
- Actually use font size variable in `timer_text` function
- Alphabetized config options in README